### PR TITLE
fix: loader name typo cancels the resolver chain

### DIFF
--- a/webpack.rules.js
+++ b/webpack.rules.js
@@ -8,7 +8,7 @@ module.exports = [
     test: /\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: '@vercel/webpack-asset-relocator-loade',
+      loader: '@vercel/webpack-asset-relocator-loader',
       options: {
         outputAssetBase: 'native_modules',
       },


### PR DESCRIPTION
This fixes `Error: Cannot find module 'bytenode'`
And allows `RangeError: Maximum call stack size exceeded` to be reproduced