### PR TITLE
Lock @vercel/webpack-asset-relocator-loader at 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@types/mocha": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
-    "@vercel/webpack-asset-relocator-loader": "^1.7.3",
+    "@vercel/webpack-asset-relocator-loader": "1.7.3",
     "chai": "^4.3.7",
     "chai-bytes": "^0.1.2",
     "css-loader": "^6.7.3",


### PR DESCRIPTION
If you download this repo and run `npm i -f` you will get the following issue. This happens because `@vercel/webpack-asset-relocator-loader` version 1.7.4 is installed because package.json specifies `^1.7.3`. However, 1.7.4 crashes with this error. Locking it at `1.7.3` fixes the issues. 

More details here: https://github.com/electron/forge/issues/3600

```
> npm run package
yarn run v1.22.19
$ electron-forge package
✔ Checking your system
✔ Preparing to package application
❯ Running packaging hooks
  ✔ Running generateAssets hook
  ❯ Running prePackage hook
    ✔ [plugin-webpack] Preparing native dependencies
    ✖ [plugin-webpack] Building webpack bundles
      › Compilation errors in the renderer: assets by status 1.36 MiB [cached] 4 assets
        runtime modules 2.58 KiB 10 modules
        javascript modules 26.5 KiB
        cacheable modules 26.1 KiB
        modules by path ./node_modules/ 22.7 KiB 10 modules
        modules by path ./src/renderer/ 3.34 KiB
        modules by path ./src/renderer/*.css 2.37 KiB 2 modules
        + 2 modules
        + 10 modules
        ./src/renderer/flower.jpg 1.34 MiB (asset) 42 bytes (javascript) [built] [code generated]
        ERROR in webpack/runtime/compat
        The installed version of @vercel/webpack-asset-relocator-loader does not appear to be compatible with Forge
```